### PR TITLE
Add ability to search for warbands and fighters

### DIFF
--- a/src/card_library.py
+++ b/src/card_library.py
@@ -2,20 +2,23 @@ from pandas import DataFrame, read_csv
 
 
 class Library:
-    def __init__(self, path: str = None):
-        self._memory = None
-        self._path = path
+    def __init__(self, card_path: str = None, warband_path: str = None):
+        self._card_memory = None
+        self._warband_memory = None
+        self._card_path = card_path
+        self._warband_path = warband_path
 
     def load(self) -> None:
-        self._memory = read_csv(self._path)
+        self._card_memory = read_csv(self._card_path)
+        self._warband_memory = read_csv(self._warband_path)
 
-    def search(self, query: str) -> DataFrame:
-        if not isinstance(self._memory, DataFrame):
+    def search_cards(self, query: str) -> DataFrame:
+        if not isinstance(self._card_memory, DataFrame):
             self.load()
 
         lowercase_query = query.lower()
-        matches = self._memory[
-            [lowercase_query in value.lower() for value in self._memory["Name"]]
+        matches = self._card_memory[
+            [lowercase_query in value.lower() for value in self._card_memory["Name"]]
         ].drop_duplicates(subset=["Name"])
 
         exact_matches = matches[
@@ -26,3 +29,34 @@ class Library:
             return exact_matches
 
         return matches
+
+    def search_warbands(self, query: str) -> DataFrame:
+        if not isinstance(self._warband_memory, DataFrame):
+            self.load()
+
+        lowercase_query = query.lower()
+        matches = self._warband_memory[
+            [lowercase_query in value.lower() for value in self._warband_memory["Name"]]
+        ]
+
+        exact_matches = matches[
+            [lowercase_query == value.lower() for value in matches["Name"]]
+        ]
+
+        if 1 == len(exact_matches):
+            return exact_matches
+
+        return matches
+
+    def get_whole_warband(self, warband_name: str) -> DataFrame:
+        if not isinstance(self._warband_memory, DataFrame):
+            self.load()
+
+        lowercase_query = warband_name.lower()
+
+        return self._warband_memory[
+            [
+                lowercase_query in value.lower()
+                for value in self._warband_memory["Warband"]
+            ]
+        ]

--- a/src/resources/warbands.csv
+++ b/src/resources/warbands.csv
@@ -1,0 +1,11 @@
+Warband,Name,ImageNumber,IsWarscroll
+The Emberwatch,The Emberwatch,0,1
+The Emberwatch,Ardorn Flamerunner,1,0
+The Emberwatch,Farasa Twice-Risen,2,0
+The Emberwatch,Yurik Velzane,3,0
+Zikkit's Tunnelpack,Zikkit's Tunnelpack,0,1
+Zikkit's Tunnelpack,Zikkit Rockgnaw,1,0
+Zikkit's Tunnelpack,Rittak Verm,2,0
+Zikkit's Tunnelpack,Krittatok,3,0
+Zikkit's Tunnelpack,Nitch Singe-snout,4,0
+Zikkit's Tunnelpack,Tik Tik,5,0


### PR DESCRIPTION
This will allow the users to search for fighters and entire warbands.
A single fighter result will display the fighter's card as main image, and the fighter's inspired version as a thumbnail.
An exact warband name match will display the warband's Warscroll as main image, with a list of fighters as the content.