### PR TITLE
Display fighters in separate embeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ __pycache__/
 
 # Logging
 logs
+
+.DS_Store

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/src/client.py
+++ b/src/client.py
@@ -5,6 +5,7 @@ import os
 from discord import Client, Intents, Message
 from src.card_library import Library
 from src.discord.message_factory import (
+    generate_fighter_embeds,
     generate_multi_embed,
     generate_single_embed,
     generate_warband_embed,
@@ -79,7 +80,7 @@ class EmbergardClient(Client):
                     )
 
                 return await message.channel.send(
-                    embed=generate_warband_embed(warband_matches),
+                    embeds=generate_fighter_embeds(warband_matches),
                 )
 
             if 0 == warband_count and 1 == card_count:

--- a/src/discord/message_factory.py
+++ b/src/discord/message_factory.py
@@ -1,3 +1,5 @@
+from ast import List
+
 from pandas import DataFrame
 
 from discord import Embed
@@ -41,15 +43,6 @@ def generate_multi_embed(card_frame: DataFrame, warband_frame: DataFrame) -> Emb
 
 
 def generate_warband_embed(frame: DataFrame) -> Embed:
-    if 1 == len(frame):
-        warband_name = frame["Warband"].array[0]
-        return (
-            Embed(title=frame["Name"].array[0])
-            .set_image(url=_warband_image_link(frame))
-            .set_thumbnail(url=_warband_image_link(frame, inspired=True))
-            .set_footer(text=f"Warband: {warband_name}")
-        )
-
     warscroll = frame[1 == frame["IsWarscroll"]]
     fighter_names = frame[0 == frame["IsWarscroll"]]["Name"].tolist()
 
@@ -65,6 +58,17 @@ def generate_warband_embed(frame: DataFrame) -> Embed:
         )
 
     return embed
+
+
+def generate_fighter_embeds(frame: DataFrame) -> List:
+    warband_name = frame["Warband"].array[0]
+
+    return [
+        Embed(title=frame["Name"].array[0]).set_image(url=_warband_image_link(frame)),
+        Embed()
+        .set_image(url=_warband_image_link(frame, inspired=True))
+        .set_footer(text=f"Warband: {warband_name}"),
+    ]
 
 
 def _build_single_description(frame: DataFrame) -> str:


### PR DESCRIPTION
To solve an issue on mobile where the embed uninspired fighter image covered the inspired fighter thumbnail, the bot will now display both sides as images in two separate embeds. This resolves #8 