### PR TITLE
Replace alternate apostrophe with the regular one in query

### DIFF
--- a/src/card_library.py
+++ b/src/card_library.py
@@ -16,7 +16,7 @@ class Library:
         if not isinstance(self._card_memory, DataFrame):
             self.load()
 
-        lowercase_query = query.lower()
+        lowercase_query = query.lower().replace("’", "'")
         matches = self._card_memory[
             [lowercase_query in value.lower() for value in self._card_memory["Name"]]
         ].drop_duplicates(subset=["Name"])
@@ -34,7 +34,7 @@ class Library:
         if not isinstance(self._warband_memory, DataFrame):
             self.load()
 
-        lowercase_query = query.lower()
+        lowercase_query = query.lower().replace("’", "'")
         matches = self._warband_memory[
             [lowercase_query in value.lower() for value in self._warband_memory["Name"]]
         ]


### PR DESCRIPTION
Certain language settings use `’` instead of `'` as apostrophe, which causes no results to be returned. This replaces that character with the regular apostrophe for the purposes of searching the card library.
