### PR TITLE
Improve searching for exact (ish) matches

### DIFF
--- a/src/card_library.py
+++ b/src/card_library.py
@@ -22,14 +22,16 @@ class Library:
         extracted = process.extract(
             lowercase_query, card_names, scorer=fuzz.partial_ratio, limit=10
         )
-        exact_match_names = [
-            match[0] for match in extracted if match[0].lower() == lowercase_query
+        exactish_match_names = [
+            match[0] for match in extracted if lowercase_query in match[0].lower()
         ]
         best_match_names = [match[0] for match in extracted if match[1] >= 80]
 
         return self._card_memory[
             self._card_memory["Name"].isin(
-                exact_match_names if 1 == len(exact_match_names) else best_match_names
+                exactish_match_names
+                if 1 == len(exactish_match_names)
+                else best_match_names
             )
         ].drop_duplicates(subset="Name")
 
@@ -42,14 +44,16 @@ class Library:
         extracted = process.extract(
             lowercase_query, warband_names, scorer=fuzz.partial_ratio, limit=10
         )
-        exact_match_names = [
-            match[0] for match in extracted if match[0].lower() == lowercase_query
+        exactish_match_names = [
+            match[0] for match in extracted if lowercase_query in match[0].lower()
         ]
         best_match_names = [match[0] for match in extracted if match[1] >= 80]
 
         return self._warband_memory[
             self._warband_memory["Name"].isin(
-                exact_match_names if 1 == len(exact_match_names) else best_match_names
+                exactish_match_names
+                if 1 == len(exactish_match_names)
+                else best_match_names
             )
         ]
 


### PR DESCRIPTION
This checks whether the query string is contained in any of the matches (instead of checking equality)  so that we can get the desired card more easily in cases where some cards are named similarly (see `Mollog` and `Ollo`).
Before this change, typing `Mollog the` would still return both fighters (thanks to peculiarities of fuzzy searching), but afterwards `Ollo` will be filtered out.